### PR TITLE
update HF client call

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -276,7 +276,7 @@ class SimpleRAGService:
                         messages=[
                             {
                                 "role": "user",
-                                "content": "What is the capital of France?"
+                                "content": prompt
                             }
                         ],
                     )

--- a/backend/main.py
+++ b/backend/main.py
@@ -16,6 +16,7 @@ from typing import List, Dict, Optional, Any
 import asyncio
 from supabase import create_client, Client
 from huggingface_hub import InferenceClient
+from huggingface_hub.utils._auth import get_token
 import logging
 import numpy as np
 
@@ -73,7 +74,7 @@ async def startup_event():
     # Environment variable check
     supabase_url = os.getenv('SUPABASE_URL')
     supabase_key = os.getenv('SUPABASE_SERVICE_ROLE_KEY')
-    hf_token = os.getenv('HF_TOKEN')
+    hf_token = os.getenv('HF_TOKEN') or get_token()
 
     logger.info("🔍 Environment check:")
     logger.info(f"   SUPABASE_URL: {'✅ Set' if supabase_url else '❌ Not set'}")
@@ -270,15 +271,16 @@ class SimpleRAGService:
             # Wrap the HF call to catch StopIteration
             def safe_hf_call():
                 try:
-                    result = hf_client.text_generation(
-                        prompt,
-                        model="unsloth/gemma-3-270m-it-GGUF",
-                        max_new_tokens=200,
-                        temperature=0.7,
-                        do_sample=True,
-                        stream=True,
-                        return_full_text=False
+                    completion = hf_client.chat.completions.create(
+                        model="HuggingFaceTB/SmolLM3-3B",
+                        messages=[
+                            {
+                                "role": "user",
+                                "content": "What is the capital of France?"
+                            }
+                        ],
                     )
+                    result = completion.choices[0].message.content
                     return result
                 except Exception as e:
                     logger.error(f"HuggingFace call failed: {str(e)}")


### PR DESCRIPTION
this pr is a fix for the client call not functioning following the logs stating 
```
ERROR:main:❌ Full traceback: Traceback (most recent call last):
  File "/app/main.py", line 275, in safe_hf_call
    result = hf_client.text_generation(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.11/site-packages/huggingface_hub/inference/_client.py", line 2375, in text_generation
    provider_helper = get_provider_helper(self.provider, task="text-generation", model=model_id)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.11/site-packages/huggingface_hub/inference/_providers/__init__.py", line 196, in get_provider_helper
    provider = next(iter(provider_mapping)).provider
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
StopIteration

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/app/main.py", line 291, in generate_answer
    response = safe_hf_call()
               ^^^^^^^^^^^^^^
  File "/app/main.py", line 287, in safe_hf_call
    raise RuntimeError(f"Text generation failed: {str(e)}")  # Fixed missing parenthesis
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Text generation failed: 

INFO:     100.64.0.2:32108 - "POST /chat HTTP/1.1" 200 OK
```
I was able to make a small reproducible to locate the issue you are facing and a samll suggestion on how to fix it at [notebook](https://colab.research.google.com/drive/1J0a3ipxxOSczeluyJpQ4sX-CCFCirvtP?usp=sharing) 

mainly the reason you are facing this is because : 
* the initual model is not hosted by any HF endpoint at the moment 
* the api call script is outdated/not working 
